### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "async": "~1.5.0",
     "lodash": "~3.10.1",
     "node-uuid": "~1.4.7",
-    "request": "~2.45.0"
+    "request": "~2.74.0"
   },
   "devDependencies": {
     "chai": "~3.4.1",


### PR DESCRIPTION
batchelor currently has a 2 vulnerable dependency paths, introducing 2 different types of known vulnerabilities.

This PR fixes vulnerable dependencies.
- [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.
- [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency.

You can see [Snyk test report](https://snyk.io/test/github/LivePersonInc/batchelor) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Stay Secure,
The Snyk Team
